### PR TITLE
Suggestions from Mike's review

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Hayroll: HARVEST Annotator for Yielding Regions of Lexical Logic
 
 ## Installation
 
-Hayroll has several major dependencies. Please install them before starting to install Hayroll. 
-The directory structure should look like this:
+Hayroll has several major dependencies. Please install them before starting to install Hayroll.
+After following the below instructions, the directory structure should look like this:
 
 ```
 installation_folder/
@@ -15,80 +15,75 @@ installation_folder/
 └── tree-sitter-c_preproc/
 ```
 
-If you change the relative position of these directories, you should update that in Hayroll's `CMakeLists.txt`.
-
 ### C2Rust
 
-https://github.com/immunant/c2rust
+[C2Rust](https://github.com/immunant/c2rust) is a static-analysis-based C-to-Rust translation tool.
 
-Recommended version: 0.19.0
+Please follow the steps on their [README](https://github.com/immunant/c2rust/blob/master/README.md#installation) to install it.  You may need to use the "Installing from Git" instructions rather than the "Installing from crates.io" instructions.  Hayroll does not need to see C2Rust's installation folder, but the `c2rust` command must be on your PATH.
 
-C2Rust is a static-analysis-based C to Rust translations tool. 
+### Maki (Hayroll-modified Version):
 
-Please follow the steps on their README to install it. Hayroll does not need to see C2Rust's installation folder, but requires the `c2rust` command to be reachable via PATH. 
+[Maki](https://github.com/UW-HARVEST/Maki) is a C macro analysis tool. Hayroll uses a modified version.
 
-### Maki (Hayroll-modified Version): 
+***HAORAN***:  This text should be moved into the Maki repository, and this text should refer the user to its README.
 
-https://github.com/UW-HARVEST/Maki
+Do not install the docker version according to its original README.  Instead, do this:
 
-Recommended version: tag 0.1.0
+```
+git clone https://github.com/UW-HARVEST/Maki.git
+cd Maki
+cmake -B build
+cmake --build build
+```
 
-The original [Maki](https://dl.acm.org/doi/abs/10.1145/3597503.3623323) is a C macro analysis tool. Hayroll modifies it and depends on that modified version. 
-
-Do not install the docker version according to its original README. Instead, please install it locally by following the common CMake build workflow. You can find a `CMakeLists.txt` at its root folder. 
-
-Maki requires the Clang toolchain `sudo apt install clang-14 llvm-14 libclang-14-dev` and the Rust toolchain https://www.rust-lang.org/tools/install. 
+Maki requires the Clang toolchain (on Ubuntu/Debian, do `sudo apt install clang-14 llvm-14 libclang-14-dev`) and the Rust toolchain https://www.rust-lang.org/tools/install.
 
 ### Z3
 
-https://github.com/Z3Prover/z3
+[Z3](https://github.com/Z3Prover/z3) is an automated theorem prover and a SAT solver.
 
-Recommended version: 4.13.4
-
-Z3 is a solver which the Hayroll Pioneer symbolic executor relies on.
-
-Please follow the common CMake installation workflow, or read `README-CMake.md` which can be found at Z3's root folder. Do not forget to run `sudo make install` as the last step. Hayroll does not need to see Z3's folder, but looks for required libraries in system paths. 
+Please follow the common CMake installation workflow, or read `README-CMake.md` which can be found at Z3's root folder. Do not forget to run `sudo make install` as the last step. Hayroll does not need to see Z3's folder, but looks for required libraries in system paths.
 
 ### Tree-sitter
 
-https://github.com/tree-sitter/tree-sitter
+[tree-sitter](https://github.com/tree-sitter/tree-sitter) is a lightweight parser generator.
 
-Recommended version: 0.25.3
-
-Tree-sitter is a lightweight parser generator. 
-
-Please simply run `make` after cloning the repo. 
+```
+git clone https://github.com/tree-sitter/tree-sitter.git
+make -C tree-sitter
+```
 
 ### Hayroll Tree-sitter-c_preproc
 
-https://github.com/UW-HARVEST/tree-sitter-c_preproc
+[tree-sitter-c_preproc](https://github.com/UW-HARVEST/tree-sitter-c_preproc) is a parser for C macros.
 
-Recommended version: tag 0.1.0
-
-Tree-sitter-c_preproc is a Tree-sitter syntax written by Hayroll for parsing C macros. 
-
-Please simply run `make` after cloning the repo. 
+```
+git clone https://github.com/UW-HARVEST/tree-sitter-c_preproc.git
+make -C tree-sitter-c_preproc
+```
 
 ### Libmcs
 
-https://gitlab.com/gtd-gmbh/libmcs
+[Libmcs](https://gitlab.com/gtd-gmbh/libmcs) is a math library. Hayroll's test suite uses it.
 
-Recommended version: 1.2.0
+It is recommended to turn off complex number support when running `./configure`, because C2Rust does not fully support complex number functionalities.
 
-Libmcs is a math library. Hayroll's test suite relies on it. 
+**HAORAN: Show the command that does that.**
 
-Please run `./configure` and `make` according to its README. 
-It is recommended to turn off complex number support when running `./configure`, because C2Rust does not fully support complex number functionalities. 
+```
+git clone https://gitlab.com/gtd-gmbh/libmcs.git
+cd libmcs
+./configure
+make
+```
 
 ### Hayroll
 
 https://github.com/UW-HARVEST/Hayroll
 
-Recommended version: tag 0.1.0
+Hayroll's core functionalities. Please install it after installing all the above dependencies, and some minor dependencies: `sudo apt install libspdlog-dev libboost-stacktrace-dev`
 
-Hayroll's core functionalities. Please install it after clearing all the above dependencies, and some minor dependencies: `sudo apt install libspdlog-dev libboost-stacktrace-dev`
-
-Then run `./build.bash`. After that, you can optionally run tests with `cd ./build; ctest`, which should take less than a minuite to finish. 
+Then run `./build.bash`. After that, you can optionally run tests with `cd ./build; ctest`, which should take less than a minuite to finish.
 
 ## Usage
 
@@ -98,7 +93,7 @@ The `./pipeline` executable (a soft link to `./build/pipeline`) offers a turn-ke
 
 ### `compile_commands.json`
 
-To build a project, a C build system typically makes multiple calls to the compiler with a long list of arguments. A `compile_commands.json` records these commands and arguments for the convenience of downstream analysis. 
+To build a project, a C build system typically makes multiple calls to the compiler with a long list of arguments. A `compile_commands.json` records these commands and arguments for the convenience of downstream analysis.
 
 There are multiple ways to generate a `compile_commands.json`, and `bear` (`sudo apt install bear`) is one easy way. For example, to generate for Libmcs, simply run `make clean; bear -- make`. Then you will see a `compile_commands.json` like:
 
@@ -133,15 +128,15 @@ There are multiple ways to generate a `compile_commands.json`, and `bear` (`sudo
 ]
 ```
 
-It's recommended to manually keep only the source files that you want to translate before sending the `compile_commands.json` to Hayroll `./pipeline`. In the Libmcs case, since Hayroll (C2Rust underneath) does not have full support for complex numbers, it's recommended to delete entires for any source files under `libm/complexf/`. 
+It's recommended to manually keep only the source files that you want to translate before sending the `compile_commands.json` to Hayroll `./pipeline`. In the Libmcs case, since Hayroll (C2Rust underneath) does not have full support for complex numbers, it's recommended to delete entires for any source files under `libm/complexf/`.
 
 ### Output
 
-`./pipeline` overwrites the output directory. You will see several intermediate files for each translation task. 
+`./pipeline` overwrites the output directory. You will see several intermediate files for each translation task.
 
-- `xxx.c`: The C source file. 
-- `xxx.cu.c`: The C compilation unit source file. This is `xxx.c` with all necessary `#include`s copy-pasted into a single file, which we call the compilation unit file. A compilation unit file is standalone compilable. 
+- `xxx.c`: The C source file.
+- `xxx.cu.c`: The C compilation unit source file. This is `xxx.c` with all necessary `#include`s copy-pasted into a single file, which we call the compilation unit file. A compilation unit file is standalone compilable.
 - `xxx.cpp2c`: Maki's macro analysis result on `xxx.cu.c`.
-- `xxx.seeded.cu.c`: `xxx.cu.c` with Hayroll's macro info tags (seeds) inserted (seeded). 
-- `xxx.seeded.rs`: `xxx.seeded.cu.c` translated to Rust by C2Rust, where C macros were expanded and translated as-is, together with Hayroll's seeds. 
+- `xxx.seeded.cu.c`: `xxx.cu.c` with Hayroll's macro info tags (seeds) inserted (seeded).
+- `xxx.seeded.rs`: `xxx.seeded.cu.c` translated to Rust by C2Rust, where C macros were expanded and translated as-is, together with Hayroll's seeds.
 - `xxx.rs`: The final output, Rust code with previously expanded C macro sections reverted into Rust functions or Rust macros.


### PR DESCRIPTION
The Hayroll installation instructions are too vague.  Instead of text like
"Please simply run `make` after cloning the repo.", it should make things easy for the user by giving exact commands that can simply be cut-and-pasted into a command shell:

```
git clone https://github.com/tree-sitter/tree-sitter.git
make -C tree-sitter
```

The Hayroll installation instructions are too complex.  Please create a new script `prerequisites.bash` that installs all the prerequisites, so that users can just run the script.  The script can contain comments so that, if there is trouble while running the `prerequisites.bash` script, users can troubleshoot.
Or, the `build.bash` script can check to see whether the `prerequisites.bash` script has already been run, and if not it can call it.  That's even simpler for users.

Update the README at https://github.com/UW-HARVEST/Maki to indicate that this is a modified version and to remove the undesirable instructions, such as those about using the Docker container.  Also move the instructions about how to install it from the Hayroll repository into that repository, and only refer to them from the Hayroll repository.

"please install it locally by following the common CMake build workflow": this should say exactly what to do.

Should the README say "recommended version" or "tested version", or should that text be removed?  I suspect it should be removed.  Some of the versions are not the latest (example: c2rust), and we don't want people going through extra effort to install an older version.  If you want to recommend a version, say what specifically is wrong with earlier and later versions.