### PR TITLE
Add --emit-c-decl-map to C2Rust wrapper

### DIFF
--- a/src/C2RustWrapper.hpp
+++ b/src/C2RustWrapper.hpp
@@ -70,6 +70,7 @@ public:
             "transpile",
             "--reorganize-definitions",
             "--emit-build-files",
+            "--emit-c-decl-map",
             compileCommandsPath.string(),
             "--output-dir", outputDirPath.string()
         };


### PR DESCRIPTION
This adds --emit-c-decl-map to the c2rust transpile invocation in C2RustWrapper, so the generated C declaration map is emitted during translation.

Question: should this be an unconditional `--emit-c-decl-map`, or should we expose it as a forwarded option instead?